### PR TITLE
fix: replace ignore_all_server_changes workaround with ignore_server_additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,12 @@ module "scc_wp" {
 
 #### CSPM configuration drift detection
 
-When CSPM is enabled (`cspm_enabled = true`), the module uses the `restapi` provider to configure the CSPM parameters. Due to a [workaround](https://github.com/Mastercard/terraform-provider-restapi/issues/319) for the restapi provider, Terraform will **not detect drift** if the following parameters are changed outside of Terraform (e.g., via the console, CLI, or API):
+When CSPM is enabled (`cspm_enabled = true`), the module uses the `restapi` provider to configure the CSPM parameters. Terraform will **not detect drift** if the following parameters are changed outside of Terraform (e.g., via the console, CLI, or API):
 
 - `enable_cspm`
 - `target_accounts` (including `account_id`, `account_type`, `config_crn`, `trusted_profile_id`)
 
 This means the CSPM configuration should be fully managed by Terraform. Any out-of-band changes will not be detected or reverted.
-
-This limitation will be resolved when the module is updated to use restapi provider v3.0.0 with `ignore_server_additions`.
 
 ### Required IAM access policies
 
@@ -109,7 +107,7 @@ statement instead the previous block.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.86.0, <2.0.0 |
-| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >=2.0.1, <3.0.0 |
+| <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >=3.0.0, <4.0.0 |
 
 ### Modules
 

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = ">=2.0.1, <3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "2.0.1"
+      version = "3.0.0"
     }
   }
 }

--- a/examples/enterprise/version.tf
+++ b/examples/enterprise/version.tf
@@ -7,7 +7,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = ">=2.0.1, <3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/main.tf
+++ b/main.tf
@@ -175,9 +175,9 @@ resource "restapi_object" "cspm" {
   read_method    = "GET"
   read_path      = "/v2/resource_instances/${ibm_resource_instance.scc_wp.guid}"
 
-  # Workaround for https://github.com/Mastercard/terraform-provider-restapi/issues/319
-  # The API returns many server-generated fields that cause drift detection.
-  # ignore_all_server_changes prevents the provider from detecting drift on
-  # fields returned by the API that weren't in our original request.
-  ignore_all_server_changes = true
+  # The API returns many server-generated fields that would otherwise cause drift detection.
+  # ignore_server_additions ensures only fields present in `data` are watched for changes,
+  # while still detecting if the server modifies a field we explicitly configured.
+  # See https://github.com/Mastercard/terraform-provider-restapi/pull/336
+  ignore_server_additions = true
 }

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "restapi_object" "cspm" {
 
   # The API returns many server-generated fields that would otherwise cause drift detection.
   # ignore_server_additions ensures only fields present in `data` are watched for changes,
-  # while still detecting if the server modifies a field we explicitly configured.
+  # while still detecting if the server modifies a field we explicitly configured
   # See https://github.com/Mastercard/terraform-provider-restapi/pull/336
   ignore_server_additions = true
 }

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "2.0.1"
+      version = "3.0.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -8,7 +8,7 @@ terraform {
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = ">=2.0.1, <3.0.0"
+      version = ">=3.0.0, <4.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades the `restapi` provider to v3.0.0, which includes the new `ignore_server_additions` attribute
- Replaces the broader `ignore_all_server_changes = true` workaround in `main.tf` with the more targeted `ignore_server_additions = true`
- With `ignore_server_additions`, Terraform will still detect drift when the server modifies a field we explicitly configured, while ignoring additional server-added fields
- Updates provider version constraints across all examples and the fully-configurable solution
- Removes the note in the README that this limitation would be resolved in v3.0.0

Closes #243